### PR TITLE
Adds sips show mode on mobile.

### DIFF
--- a/src/app/components/mobile-controls/mobile-controls.component.html
+++ b/src/app/components/mobile-controls/mobile-controls.component.html
@@ -1,7 +1,8 @@
-<h5>{{ user.username }}</h5>
-<p>{{ sips }} sip{{ sips > 1 ? "s" : "" }} left in beer {{ beers + 1 }}</p>
 
-<hr />
+
+<h5>{{ user.username }}</h5>
+<p [innerHTML]=total_sips (click)="toggleSips()"></p>
+
 
 <button mat-raised-button color="primary" (click)="draw()">Draw card</button>
 <div class="row">

--- a/src/app/components/mobile-controls/mobile-controls.component.ts
+++ b/src/app/components/mobile-controls/mobile-controls.component.ts
@@ -13,15 +13,17 @@ import { User } from "src/app/models/user";
 })
 export class MobileControlsComponent implements OnInit {
   public user: User;
-  public beers: number;
-  public sips: number;
+  public total_sips: string;
+  private simple_sips: boolean;
 
   constructor(
     public gameService: GameService,
     public sounds: SoundService,
     public meta: MetaService,
     private bottomSheet: MatBottomSheet
-  ) {}
+  ) {
+    this.simple_sips = false;
+  }
 
   ngOnInit() {
     this.gameService.onCardDrawn.subscribe(() => {
@@ -39,9 +41,16 @@ export class MobileControlsComponent implements OnInit {
     this.user = this.gameService.getActivePlayer();
 
     const cards = this.gameService.getCardsForPlayer(this.user);
+    const sips = this.meta.getSipsLeftInBeer(cards);
 
-    this.beers = this.meta.getBeers(cards);
-    this.sips = this.meta.getSipsLeftInBeer(cards);
+    this.total_sips = this.simple_sips ? 
+                        this.meta.getTotalSips(cards) + "<sub>14</sub>" 
+                        : `${sips} sip${sips > 1 ? "s" : ""} left in beer ${this.meta.getBeers(cards) + 1}`;
+  }
+
+  public toggleSips() {
+    this.simple_sips = !this.simple_sips;
+    this.update();
   }
 
   public draw() {


### PR DESCRIPTION
Users can now click the text "x sip(s) left in beer y"  when in mobile view to change it to the base 14 representation. This makes it consistent with the stats view, and is for some people easier to parse.

It is currently _not_ set as the default and  functionality is otherwise unchanged.